### PR TITLE
Add loading states and snackbar feedback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Watchlist from "./pages/Watchlist";
 import StockDetail from "./components/StockDetail";
 import Settings from "./pages/Settings";
 import AiAssistant from "./pages/AiAssistant";
+import GlobalSnackbar from "./components/GlobalSnackbar";
 
 const App = () => {
   return (
@@ -14,11 +15,12 @@ const App = () => {
 
       <Routes>
         <Route path="/" element={<Dashboard />} />
-        <Route path="/wishlist" element={<Watchlist />} />
+        <Route path="/watchlist" element={<Watchlist />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/ai" element={<AiAssistant />} />
         <Route path="/stock/:symbol" element={<StockDetail />} />
       </Routes>
+      <GlobalSnackbar />
     </>
   );
 };

--- a/src/components/GlobalSnackbar.jsx
+++ b/src/components/GlobalSnackbar.jsx
@@ -1,0 +1,32 @@
+import { Snackbar, Alert } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { closeSnackbar } from "../redux/slices/uiSlice";
+
+const GlobalSnackbar = () => {
+  const dispatch = useDispatch();
+  const { open, message, severity } = useSelector((state) => state.ui.snackbar);
+
+  const handleClose = (_, reason) => {
+    if (reason === "clickaway") return;
+    dispatch(closeSnackbar());
+  };
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={3000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+    >
+      <Alert
+        onClose={handleClose}
+        severity={severity || "info"}
+        sx={{ width: "100%" }}
+      >
+        {message}
+      </Alert>
+    </Snackbar>
+  );
+};
+
+export default GlobalSnackbar;

--- a/src/components/MarketOverview.jsx
+++ b/src/components/MarketOverview.jsx
@@ -1,8 +1,8 @@
-import { Box, Typography, Grid } from "@mui/material";
+import { Box, Typography, Grid, CircularProgress } from "@mui/material";
 import { useSelector } from "react-redux";
 
 const MarketOverview = () => {
-  const { nifty, sensex, bankNifty } = useSelector((state) => state.market);
+  const { nifty, sensex, bankNifty, loading } = useSelector((state) => state.market);
 
   const indices = [
     { name: "NIFTY 50", ...nifty },
@@ -24,40 +24,46 @@ const MarketOverview = () => {
         📊 Market Overview
       </Typography>
 
-      <Grid container spacing={2}>
-        {indices.map((index) => (
-          <Grid size={{ md: 4 }} key={index.name}>
-            <Box
-              sx={{
-                backgroundColor: "background.paper",
-                color: "white",
-                borderRadius: 1,
-                p: 4,
-              }}
-            >
-              <Typography
-                variant="subtitle1"
-                fontWeight={600}
-                color="text.secondary"
-                gutterBottom
+      {loading ? (
+        <Box textAlign="center" mt={4}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Grid container spacing={2}>
+          {indices.map((index) => (
+            <Grid size={{ md: 4 }} key={index.name}>
+              <Box
+                sx={{
+                  backgroundColor: "background.paper",
+                  color: "white",
+                  borderRadius: 1,
+                  p: 4,
+                }}
               >
-                {index.name}
-              </Typography>
-              <Typography variant="h5" fontWeight={700} gutterBottom>
-                ₹{index.value}
-              </Typography>
-              <Typography
-                variant="body2"
-                fontWeight={500}
-                color={getColor(index.change)}
-              >
-                {index.change >= 0 ? "+" : ""}
-                {index.change} ({index.percent}%)
-              </Typography>
-            </Box>
-          </Grid>
-        ))}
-      </Grid>
+                <Typography
+                  variant="subtitle1"
+                  fontWeight={600}
+                  color="text.secondary"
+                  gutterBottom
+                >
+                  {index.name}
+                </Typography>
+                <Typography variant="h5" fontWeight={700} gutterBottom>
+                  ₹{index.value}
+                </Typography>
+                <Typography
+                  variant="body2"
+                  fontWeight={500}
+                  color={getColor(index.change)}
+                >
+                  {index.change >= 0 ? "+" : ""}
+                  {index.change} ({index.percent}%)
+                </Typography>
+              </Box>
+            </Grid>
+          ))}
+        </Grid>
+      )}
     </Box>
   );
 };

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -7,7 +7,7 @@ import { SmartToy } from "@mui/icons-material";
 
 const navLinks = [
   { lable: "Dashboard", path: "/", icon: <TrendingUp /> },
-  { lable: "Wishlist", path: "/wishlist", icon: <FavoriteOutlined /> },
+  { lable: "Watchlist", path: "/watchlist", icon: <FavoriteOutlined /> },
   { lable: "Settings", path: "/settings", icon: <Settings /> },
   { lable: "AI Assistant", path: "/ai", icon: <SmartToy /> },
 ];

--- a/src/components/StockDetail.jsx
+++ b/src/components/StockDetail.jsx
@@ -2,6 +2,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { useState, useEffect } from "react";
 import { toggleWatchlist } from "../redux/slices/watchlistSlice";
+import { showSnackbar } from "../redux/slices/uiSlice";
 import {
   Box,
   Typography,
@@ -84,6 +85,7 @@ const StockDetail = () => {
   }
 
   const handleToggleWatchlist = () => {
+    const exists = watchlist.some((item) => item.symbol === symbol);
     dispatch(
       toggleWatchlist({
         symbol,
@@ -91,6 +93,12 @@ const StockDetail = () => {
         ltp: quote.c,
         change: quote.d,
         change_percent: quote.dp,
+      })
+    );
+    dispatch(
+      showSnackbar({
+        message: exists ? "Removed from watchlist" : "Added to watchlist",
+        severity: "success",
       })
     );
   };

--- a/src/components/TrendingStocks.jsx
+++ b/src/components/TrendingStocks.jsx
@@ -1,15 +1,16 @@
 import { useEffect } from "react";
-import { Box, Typography, Grid } from "@mui/material";
+import { Box, Typography, Grid, CircularProgress } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchTrendingStocks } from "../redux/slices/stockSlice";
 import { toggleWatchlist } from "../redux/slices/watchlistSlice";
+import { showSnackbar } from "../redux/slices/uiSlice";
 import StockCard from "./StockCard";
 import TrendingUp from "@mui/icons-material/TrendingUp";
 
 const TrendingStocks = () => {
   const dispatch = useDispatch();
 
-  const trending = useSelector((state) => state.stocks.trending);
+  const { trending, loading } = useSelector((state) => state.stocks);
   const watchlist = useSelector((state) => state.watchlist.items);
 
   useEffect(() => {
@@ -17,7 +18,14 @@ const TrendingStocks = () => {
   }, [dispatch]);
 
   const handleToggleWatchlist = (stock) => {
+    const exists = watchlist.some((s) => s.symbol === stock.symbol);
     dispatch(toggleWatchlist(stock));
+    dispatch(
+      showSnackbar({
+        message: exists ? "Removed from watchlist" : "Added to watchlist",
+        severity: "success",
+      })
+    );
   };
 
   return (
@@ -33,18 +41,24 @@ const TrendingStocks = () => {
         />
         Trending Stocks
       </Typography>
-      <Grid container spacing={4}>
-        {trending.map((stock) => (
-          <Grid item xs={12} md={8} key={stock.symbol}>
-            <StockCard
-              key={stock.symbol}
-              stock={stock}
-              isFavorite={watchlist.some((s) => s.symbol === stock.symbol)}
-              onToggleFavorite={() => handleToggleWatchlist(stock)}
-            />
-          </Grid>
-        ))}
-      </Grid>
+      {loading ? (
+        <Box textAlign="center" mt={4}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Grid container spacing={4}>
+          {trending.map((stock) => (
+            <Grid item xs={12} md={8} key={stock.symbol}>
+              <StockCard
+                key={stock.symbol}
+                stock={stock}
+                isFavorite={watchlist.some((s) => s.symbol === stock.symbol)}
+                onToggleFavorite={() => handleToggleWatchlist(stock)}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      )}
     </Box>
   );
 };

--- a/src/components/WatchlistPreview.jsx
+++ b/src/components/WatchlistPreview.jsx
@@ -11,6 +11,7 @@ import { FavoriteBorderOutlined, Close } from "@mui/icons-material";
 import { useSelector, useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { toggleWatchlist } from "../redux/slices/watchlistSlice";
+import { showSnackbar } from "../redux/slices/uiSlice";
 
 const WatchlistPreview = ({ limit = 4, isFullView = false }) => {
   const watchlist = useSelector((state) => state.watchlist.items);
@@ -21,6 +22,9 @@ const WatchlistPreview = ({ limit = 4, isFullView = false }) => {
 
   const handleRemove = (stock) => {
     dispatch(toggleWatchlist(stock));
+    dispatch(
+      showSnackbar({ message: "Removed from watchlist", severity: "success" })
+    );
   };
 
   if (watchlist.length === 0) {
@@ -106,7 +110,13 @@ const WatchlistPreview = ({ limit = 4, isFullView = false }) => {
                 />
               </Box>
               {isFullView && (
-                <IconButton onClick={() => handleRemove(stock)} size="small">
+                <IconButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRemove(stock);
+                  }}
+                  size="small"
+                >
                   <Close sx={{ fontSize: 20, color: "text.secondary" }} />
                 </IconButton>
               )}
@@ -119,7 +129,7 @@ const WatchlistPreview = ({ limit = 4, isFullView = false }) => {
         <Box mt={2} display="flex" justifyContent="center">
           <Button
             size="small"
-            onClick={() => navigate("/wishlist")}
+            onClick={() => navigate("/watchlist")}
             sx={{ color: "success.main" }}
           >
             +{watchlist.length - limit} more stocks

--- a/src/components/WatchlistSidebar.jsx
+++ b/src/components/WatchlistSidebar.jsx
@@ -31,7 +31,7 @@ const WatchlistSidebar = () => {
           />
           Your Watchlist
         </Typography>
-        <Button size="small" onClick={() => navigate("/wishlist")}>
+        <Button size="small" onClick={() => navigate("/watchlist")}>
           View All
         </Button>
       </Box>

--- a/src/redux/slices/uiSlice.js
+++ b/src/redux/slices/uiSlice.js
@@ -1,0 +1,24 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const uiSlice = createSlice({
+  name: "ui",
+  initialState: {
+    snackbar: {
+      open: false,
+      message: "",
+      severity: "info",
+    },
+  },
+  reducers: {
+    showSnackbar: (state, action) => {
+      const { message, severity = "info" } = action.payload;
+      state.snackbar = { open: true, message, severity };
+    },
+    closeSnackbar: (state) => {
+      state.snackbar.open = false;
+    },
+  },
+});
+
+export const { showSnackbar, closeSnackbar } = uiSlice.actions;
+export default uiSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -3,6 +3,7 @@ import stockReducer from "./slices/stockSlice";
 import watchlistReducer from "./slices/watchlistSlice";
 import searchReducer from "./slices/searchSlice";
 import marketReducer from "./slices/marketSlice";
+import uiReducer from "./slices/uiSlice";
 
 export const store = configureStore({
   reducer: {
@@ -10,5 +11,6 @@ export const store = configureStore({
     watchlist: watchlistReducer,
     search: searchReducer,
     market: marketReducer,
+    ui: uiReducer,
   },
 });


### PR DESCRIPTION
## Summary
- show global snackbar via Redux slice
- add loading states for trending and market overview
- notify user when toggling watchlist
- wire snackbar provider into app
- rename Wishlist path to Watchlist and stop unintended navigation when removing items

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852da8293788321bc9341d7c08d4c02