### PR TITLE
Fix responsive AppBar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,9 +1,25 @@
-import { AppBar, Toolbar, Box, Typography, Button } from "@mui/material";
+import {
+  AppBar,
+  Toolbar,
+  Box,
+  Typography,
+  Button,
+  IconButton,
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  useTheme,
+  useMediaQuery,
+} from "@mui/material";
 import { Link, useLocation } from "react-router-dom";
 import TrendingUp from "@mui/icons-material/TrendingUp";
 import Settings from "@mui/icons-material/Settings";
 import FavoriteOutlined from "@mui/icons-material/FavoriteOutlined";
-import { SmartToy } from "@mui/icons-material";
+import { SmartToy, Menu } from "@mui/icons-material";
+import { useState } from "react";
 
 const navLinks = [
   { lable: "Dashboard", path: "/", icon: <TrendingUp /> },
@@ -14,6 +30,33 @@ const navLinks = [
 
 const Navbar = () => {
   const location = useLocation();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const toggleDrawer = (open) => () => {
+    setDrawerOpen(open);
+  };
+
+  const drawerContent = (
+    <Box sx={{ width: 250 }} role="presentation" onClick={toggleDrawer(false)}>
+      <List>
+        {navLinks.map((link) => (
+          <ListItem key={link.path} disablePadding>
+            <ListItemButton
+              component={Link}
+              to={link.path}
+              selected={location.pathname === link.path}
+            >
+              <ListItemIcon>{link.icon}</ListItemIcon>
+              <ListItemText primary={link.lable} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+
   return (
     <AppBar
       position="static"
@@ -33,34 +76,45 @@ const Navbar = () => {
         >
           Stocklyzer
         </Typography>
-        <Box display="flex" gap={4}>
-          {navLinks.map((link) => (
-            <Button
-              key={link.path}
-              component={Link}
-              to={link.path}
-              startIcon={link.icon}
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                color: "primary.contrastText",
-                padding: "8px 16px",
-                backgroundColor:
-                  location.pathname === link.path
-                    ? "primary.light"
-                    : "transparent",
-                borderRadius: "8px",
-                fontSize: "16px",
-                fontWeight: 500,
-                "&:hover": {
-                  backgroundColor: "primary.light",
-                },
-              }}
-            >
-              {link.lable}
-            </Button>
-          ))}
-        </Box>
+        {isMobile ? (
+          <>
+            <IconButton color="inherit" onClick={toggleDrawer(true)}>
+              <Menu />
+            </IconButton>
+            <Drawer anchor="right" open={drawerOpen} onClose={toggleDrawer(false)}>
+              {drawerContent}
+            </Drawer>
+          </>
+        ) : (
+          <Box display="flex" gap={4}>
+            {navLinks.map((link) => (
+              <Button
+                key={link.path}
+                component={Link}
+                to={link.path}
+                startIcon={link.icon}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  color: "primary.contrastText",
+                  padding: "8px 16px",
+                  backgroundColor:
+                    location.pathname === link.path
+                      ? "primary.light"
+                      : "transparent",
+                  borderRadius: "8px",
+                  fontSize: "16px",
+                  fontWeight: 500,
+                  "&:hover": {
+                    backgroundColor: "primary.light",
+                  },
+                }}
+              >
+                {link.lable}
+              </Button>
+            ))}
+          </Box>
+        )}
       </Toolbar>
     </AppBar>
   );


### PR DESCRIPTION
## Summary
- add Drawer and IconButton to support mobile
- toggle navbar links on smaller screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853afcca7f0832195f96e18b63507eb