### PR TITLE
Persist watchlist in localStorage

### DIFF
--- a/src/redux/slices/watchlistSlice.js
+++ b/src/redux/slices/watchlistSlice.js
@@ -1,9 +1,19 @@
 import { createSlice } from "@reduxjs/toolkit";
 
+const getInitialWatchlist = () => {
+  if (typeof localStorage === "undefined") return [];
+  try {
+    const stored = localStorage.getItem("watchlist");
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+};
+
 const watchlistSlice = createSlice({
   name: "watchlist",
   initialState: {
-    items: [],
+    items: getInitialWatchlist(),
   },
   reducers: {
     toggleWatchlist: (state, action) => {
@@ -16,6 +26,9 @@ const watchlistSlice = createSlice({
         );
       } else {
         state.items.push(action.payload);
+      }
+      if (typeof localStorage !== "undefined") {
+        localStorage.setItem("watchlist", JSON.stringify(state.items));
       }
     },
   },


### PR DESCRIPTION
## Summary
- load watchlist from localStorage on startup
- persist any watchlist changes back to localStorage

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853be8809b083218641c54ba01435ce